### PR TITLE
AB v0.5 support

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -34,7 +34,7 @@ ZipFile = "a5390f91-8eb1-5f08-bee0-b1d1ffed6cea"
 [compat]
 ACEbase = "0.4"
 AlgebraicMultigrid = "0.5, 0.6"
-AtomsBase = "0.4"
+AtomsBase = "0.5"
 Calculus = "0.5"
 CommonSubexpressions = "0.2, 0.3"
 DataDeps = "0.7"

--- a/src/atoms.jl
+++ b/src/atoms.jl
@@ -95,10 +95,10 @@ function Atoms(sys::AtomsBase.AbstractSystem)
    V = [ ustrip.(u"eV^0.5/u^0.5", AtomsBase.velocity(sys,i) ) for i in 1:length(sys)  ]
    M = [ ustrip(u"u", AtomsBase.atomic_mass(sys,i) ) for i in 1:length(sys) ]
    Z = [ (AtomicNumber ∘ AtomsBase.atomic_number)(sys,i) for i in 1:length(sys) ]
-   cell = map( x -> ustrip.(u"Å", x), sys[:bounding_box])
+   cell = map( x -> ustrip.(u"Å", x), sys[:cell_vectors])
    pbc = JVec(AtomsBase.periodicity(sys))
    data = Dict{Any,JData{eltype(M)}}( String(key)=>JData(sys[key]) for key in keys(sys) 
-      if !( key in (:bounding_box, :periodicity) )
+      if !( key in (:cell_vectors, :periodicity) )
    )
    return JuLIP.Atoms(X, M .* V, M, Z, hcat(cell...)', pbc, nothing; data=data)
 end

--- a/test/test_atomsbase.jl
+++ b/test/test_atomsbase.jl
@@ -18,10 +18,10 @@ att = Atoms(ab)
 @test at.cell ≈ att.cell
 @test at.M ≈ att.M
 
-@test all( ab[:bounding_box] .≈ abc[:bounding_box] )
+@test all( ab[:cell_vectors] .≈ abc[:cell_vectors] )
 @test at.cell ≈ att.cell
 map( 1:3 ) do i
-    @test ustrip.(u"Å", ab[:bounding_box][i]) ≈ at.cell[i,:]
+    @test ustrip.(u"Å", ab[:cell_vectors][i]) ≈ at.cell[i,:]
 end
 
 # Test position conversion
@@ -59,6 +59,6 @@ aj = JuLIP.Atoms(ab)
 
 ab2 = FlexibleSystem(aj)
 
-@test all( bounding_box(ab) .≈ bounding_box(ab2) )
-@test bounding_box(ab)[2][3] ≈ aj.cell[2,3] * u"Å"
-@test bounding_box(ab)[3][2] ≈ aj.cell[3,2] * u"Å"
+@test all( cell_vectors(ab) .≈ cell_vectors(ab2) )
+@test cell_vectors(ab)[2][3] ≈ aj.cell[2,3] * u"Å"
+@test cell_vectors(ab)[3][2] ≈ aj.cell[3,2] * u"Å"


### PR DESCRIPTION
This pulls in AB v0.5 so that ACEpotentials v0.6 can be update

This is needed to use ACEpotentials with Molly atm.